### PR TITLE
고객입장에서 채팅방 총 페이지 수가 다르게 나오는 현상 수정

### DIFF
--- a/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryImpl.java
@@ -74,7 +74,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryQueryDsl {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        Long count = getPageCount(company, chatRoom);
+        Long count = getPageCountByCompany(company, chatRoom);
 
         return new PageImpl<>(chatRooms, pageable, count);
     }
@@ -109,7 +109,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryQueryDsl {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        Long count = getPageCount(customer, chatRoom);
+        Long count = getPageCountByCustomer(customer, chatRoom);
 
         return new PageImpl<>(chatRooms, pageable, count);
     }
@@ -136,11 +136,19 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryQueryDsl {
                 .where(message.chatRoomId.eq(chatRoom.id));
     }
 
-    private Long getPageCount(Username company, QChatRoom chatRoom) {
+    private Long getPageCountByCompany(Username company, QChatRoom chatRoom) {
         return queryFactory
                 .select(chatRoom.count())
                 .from(chatRoom)
                 .where(chatRoom.company.eq(company))
+                .fetchOne();
+    }
+
+    private Long getPageCountByCustomer(Username customer, QChatRoom chatRoom) {
+        return queryFactory
+                .select(chatRoom.count())
+                .from(chatRoom)
+                .where(chatRoom.customer.eq(customer))
                 .fetchOne();
     }
 }


### PR DESCRIPTION
원인: 고객 입장일 때도 기업입장에서의 총 페이지 수가 나오도록 쿼리가 작성되어 있었음
해결: 총 페이지 수를 구하는 메서드를 기업입장과 고객입장으로 분리