### PR TITLE
SseEmitter를 이용해 채팅방 갱신 기능 구현

### DIFF
--- a/src/main/java/com/junhyeong/chatchat/applications/message/SendMessageService.java
+++ b/src/main/java/com/junhyeong/chatchat/applications/message/SendMessageService.java
@@ -36,13 +36,7 @@ public class SendMessageService {
     public void sendMessage(MessageRequest messageRequest) {
         Long senderId = messageRequest.getSenderId();
 
-        Username username = switch (messageRequest.getRole()) {
-            case "company" -> companyRepository.findById(senderId)
-                    .orElseThrow(CompanyNotFound::new).username();
-            case "customer" -> customerRepository.findById(senderId)
-                    .orElseThrow(CustomerNotFound::new).username();
-            default -> throw new UnknownRole();
-        };
+        Username username = getUsername(messageRequest, senderId);
 
         Message message = new Message(
                 messageRequest.getChatRoomId(),
@@ -57,5 +51,15 @@ public class SendMessageService {
                 "/sub/chatrooms/" + saved.chatRoomId(),
                 saved.toDto()
         );
+    }
+
+    private Username getUsername(MessageRequest messageRequest, Long senderId) {
+        return switch (messageRequest.getRole()) {
+            case "company" -> companyRepository.findById(senderId)
+                    .orElseThrow(CompanyNotFound::new).username();
+            case "customer" -> customerRepository.findById(senderId)
+                    .orElseThrow(CustomerNotFound::new).username();
+            default -> throw new UnknownRole();
+        };
     }
 }

--- a/src/main/java/com/junhyeong/chatchat/applications/notification/MessageNotificationService.java
+++ b/src/main/java/com/junhyeong/chatchat/applications/notification/MessageNotificationService.java
@@ -1,0 +1,118 @@
+package com.junhyeong.chatchat.applications.notification;
+
+import com.junhyeong.chatchat.dtos.ChatRoomDto;
+import com.junhyeong.chatchat.dtos.MessageRequest;
+import com.junhyeong.chatchat.exceptions.ChatRoomNotFound;
+import com.junhyeong.chatchat.exceptions.CompanyNotFound;
+import com.junhyeong.chatchat.exceptions.CustomerNotFound;
+import com.junhyeong.chatchat.exceptions.UnknownRole;
+import com.junhyeong.chatchat.models.chatRoom.ChatRoom;
+import com.junhyeong.chatchat.models.commom.Username;
+import com.junhyeong.chatchat.models.company.Company;
+import com.junhyeong.chatchat.models.customer.Customer;
+import com.junhyeong.chatchat.repositories.chatRoom.ChatRoomRepository;
+import com.junhyeong.chatchat.repositories.company.CompanyRepository;
+import com.junhyeong.chatchat.repositories.customer.CustomerRepository;
+import com.junhyeong.chatchat.repositories.sseEmitter.SseEmitterRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Service
+public class MessageNotificationService {
+    private final SseEmitterRepository sseEmitterRepository;
+    private final CompanyRepository companyRepository;
+    private final CustomerRepository customerRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+
+
+    public MessageNotificationService(SseEmitterRepository sseEmitterRepository,
+                                      CompanyRepository companyRepository,
+                                      CustomerRepository customerRepository,
+                                      ChatRoomRepository chatRoomRepository) {
+        this.sseEmitterRepository = sseEmitterRepository;
+        this.companyRepository = companyRepository;
+        this.customerRepository = customerRepository;
+        this.chatRoomRepository = chatRoomRepository;
+    }
+
+    @Transactional
+    public SseEmitter subscribe(Username username, String userType) {
+        Long userId = getUserId(username, userType);
+
+        String id = userId + "_" + System.currentTimeMillis();
+
+        SseEmitter sseEmitter = createEmitter(id);
+
+        sendToClient(sseEmitter, id, "Connected!");
+
+        return sseEmitter;
+    }
+
+    private Long getUserId(Username username, String userType) {
+        return switch (userType) {
+            case "company" -> companyRepository.findByUsername(username)
+                    .orElseThrow(CompanyNotFound::new).id();
+            case "customer" -> customerRepository.findByUsername(username)
+                    .orElseThrow(CustomerNotFound::new).id();
+            default -> throw new UnknownRole();
+        };
+    }
+
+    private void sendToClient(SseEmitter sseEmitter, String id, Object data) {
+        try {
+            sseEmitter.send(SseEmitter.event()
+                    .id(id)
+                    .name("sse")
+                    .data(data));
+        } catch (IOException exception) {
+            sseEmitterRepository.deleteById(id);
+            sseEmitter.completeWithError(exception);
+        }
+    }
+
+    private SseEmitter createEmitter(String id) {
+        SseEmitter sseEmitter = sseEmitterRepository.save(id, new SseEmitter(DEFAULT_TIMEOUT));
+
+        sseEmitter.onCompletion(() -> sseEmitterRepository.deleteById(id));
+        sseEmitter.onTimeout(() -> sseEmitterRepository.deleteById(id));
+
+        return sseEmitter;
+    }
+
+    public void sendNotification(MessageRequest messageRequest) {
+        ChatRoom chatRoom = chatRoomRepository.findById(messageRequest.getChatRoomId())
+                .orElseThrow(ChatRoomNotFound::new);
+
+        Customer customer = customerRepository.findByUsername(chatRoom.customer())
+                .orElseThrow(CustomerNotFound::new);
+        sendChatRoomInformation(String.valueOf(customer.id()), customer.username(), "customer");
+
+        Company company = companyRepository.findByUsername(chatRoom.company())
+                .orElseThrow(CompanyNotFound::new);
+        sendChatRoomInformation(String.valueOf(company.id()), company.username(), "company");
+    }
+
+    private void sendChatRoomInformation(String id, Username username, String userType) {
+        Map<String, SseEmitter> sseEmitters = sseEmitterRepository.findAllByUserId(id);
+
+        ChatRoomDto chatRoomDto = getChatRoomDto(username, userType);
+
+        sseEmitters.forEach(
+                (key, emitter) -> sendToClient(emitter, key, chatRoomDto)
+        );
+    }
+
+    private ChatRoomDto getChatRoomDto(Username username, String userType) {
+        return switch (userType) {
+            case "company" -> chatRoomRepository.findDtoByCompany(username);
+            case "customer" -> chatRoomRepository.findDtoByCustomer(username);
+            default -> throw new UnknownRole();
+        };
+    }
+}

--- a/src/main/java/com/junhyeong/chatchat/controllers/common/MessageController.java
+++ b/src/main/java/com/junhyeong/chatchat/controllers/common/MessageController.java
@@ -1,6 +1,7 @@
 package com.junhyeong.chatchat.controllers.common;
 
 import com.junhyeong.chatchat.applications.message.SendMessageService;
+import com.junhyeong.chatchat.applications.notification.MessageNotificationService;
 import com.junhyeong.chatchat.dtos.MessageRequest;
 import com.junhyeong.chatchat.dtos.MessageRequestDto;
 import com.junhyeong.chatchat.exceptions.UnknownRole;
@@ -13,9 +14,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class MessageController {
     private final SendMessageService sendMessageService;
+    private final MessageNotificationService messageNotificationService;
 
-    public MessageController(SendMessageService sendMessageService) {
+    public MessageController(SendMessageService sendMessageService,
+                             MessageNotificationService messageNotificationService) {
         this.sendMessageService = sendMessageService;
+        this.messageNotificationService = messageNotificationService;
     }
 
     @MessageMapping("/messages")
@@ -23,6 +27,8 @@ public class MessageController {
         MessageRequest messageRequest = MessageRequest.of(messageRequestDto);
 
         sendMessageService.sendMessage(messageRequest);
+
+        messageNotificationService.sendNotification(messageRequest);
     }
 
     @ExceptionHandler(UnknownRole.class)

--- a/src/main/java/com/junhyeong/chatchat/controllers/common/NotificationController.java
+++ b/src/main/java/com/junhyeong/chatchat/controllers/common/NotificationController.java
@@ -1,0 +1,27 @@
+package com.junhyeong.chatchat.controllers.common;
+
+import com.junhyeong.chatchat.applications.notification.MessageNotificationService;
+import com.junhyeong.chatchat.models.commom.Username;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+public class NotificationController {
+    private final MessageNotificationService messageNotificationService;
+
+    public NotificationController(MessageNotificationService messageNotificationService) {
+        this.messageNotificationService = messageNotificationService;
+    }
+
+    @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter connect(
+            @RequestAttribute Username username,
+            @RequestParam("userType") String userType
+    ) {
+        return messageNotificationService.subscribe(username, userType);
+    }
+}

--- a/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryQueryDsl.java
+++ b/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryQueryDsl.java
@@ -8,4 +8,6 @@ import org.springframework.data.domain.Pageable;
 public interface ChatRoomRepositoryQueryDsl {
     Page<ChatRoomDto> findAllDtoByCompany(Username company, Pageable pageable);
     Page<ChatRoomDto> findAllDtoByCustomer(Username company, Pageable pageable);
+    ChatRoomDto findDtoByCompany(Username company);
+    ChatRoomDto findDtoByCustomer(Username company);
 }

--- a/src/main/java/com/junhyeong/chatchat/repositories/sseEmitter/SseEmitterRepository.java
+++ b/src/main/java/com/junhyeong/chatchat/repositories/sseEmitter/SseEmitterRepository.java
@@ -1,0 +1,28 @@
+package com.junhyeong.chatchat.repositories.sseEmitter;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Repository
+public class SseEmitterRepository {
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter save(String id, SseEmitter sseEmitter) {
+        emitters.put(id, sseEmitter);
+        return sseEmitter;
+    }
+
+    public void deleteById(String id) {
+        emitters.remove(id);
+    }
+
+    public Map<String, SseEmitter> findAllByUserId(String id) {
+        return emitters.entrySet().stream()
+                .filter(entry -> entry.getKey().split("_")[0].equals(id))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/src/main/java/com/junhyeong/chatchat/utils/JwtUtil.java
+++ b/src/main/java/com/junhyeong/chatchat/utils/JwtUtil.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 
 public class JwtUtil {
     private final Algorithm algorithm;
-    private final Long ACCESS_TOKEN_VALIDATION_SECOND = 1000L * 60 * 3;
+    private final Long ACCESS_TOKEN_VALIDATION_SECOND = 1000L * 60 * 30;
     private final Long REFRESH_TOKEN_VALIDATION_SECOND = 1000L * 60 * 60 * 24 * 14;
 
     public JwtUtil(String secret) {


### PR DESCRIPTION
채팅방 목록 갱신을 위해 SseEmitter를 이용하여 갱신 알림 및 메세지를 받도록 함

- 알림을 보내는 로직 Service 생성
- 로그인한 사용자의 accessToken을 전달받아 사용자 고유의 아이디로 연결