### PR TITLE
chatRoomDto 쿼리 문제 해결

### DIFF
--- a/src/main/java/com/junhyeong/chatchat/applications/notification/MessageNotificationService.java
+++ b/src/main/java/com/junhyeong/chatchat/applications/notification/MessageNotificationService.java
@@ -91,27 +91,29 @@ public class MessageNotificationService {
 
         Customer customer = customerRepository.findByUsername(chatRoom.customer())
                 .orElseThrow(CustomerNotFound::new);
-        sendChatRoomInformation(String.valueOf(customer.id()), customer.username(), "customer");
+        sendChatRoomInformation(String.valueOf(
+                customer.id()), customer.username(), "customer", chatRoom.id());
 
         Company company = companyRepository.findByUsername(chatRoom.company())
                 .orElseThrow(CompanyNotFound::new);
-        sendChatRoomInformation(String.valueOf(company.id()), company.username(), "company");
+        sendChatRoomInformation(String.valueOf(
+                company.id()), company.username(), "company", chatRoom.id());
     }
 
-    private void sendChatRoomInformation(String id, Username username, String userType) {
+    private void sendChatRoomInformation(String id, Username username, String userType, Long chatRoomId) {
         Map<String, SseEmitter> sseEmitters = sseEmitterRepository.findAllByUserId(id);
 
-        ChatRoomDto chatRoomDto = getChatRoomDto(username, userType);
+        ChatRoomDto chatRoomDto = getChatRoomDto(username, userType, chatRoomId);
 
         sseEmitters.forEach(
                 (key, emitter) -> sendToClient(emitter, key, chatRoomDto)
         );
     }
 
-    private ChatRoomDto getChatRoomDto(Username username, String userType) {
+    private ChatRoomDto getChatRoomDto(Username username, String userType, Long chatRoomId) {
         return switch (userType) {
-            case "company" -> chatRoomRepository.findDtoByCompany(username);
-            case "customer" -> chatRoomRepository.findDtoByCustomer(username);
+            case "company" -> chatRoomRepository.findDtoByCompany(username, chatRoomId);
+            case "customer" -> chatRoomRepository.findDtoByCustomer(username, chatRoomId);
             default -> throw new UnknownRole();
         };
     }

--- a/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryImpl.java
@@ -117,7 +117,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryQueryDsl {
     }
 
     @Override
-    public ChatRoomDto findDtoByCompany(Username company) {
+    public ChatRoomDto findDtoByCompany(Username company, Long chatRoomId) {
         QChatRoom chatRoom = QChatRoom.chatRoom;
         QMessage message = QMessage.message;
         QCustomer customer = QCustomer.customer;
@@ -136,7 +136,8 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryQueryDsl {
                 .on(chatRoom.id.eq(message.chatRoomId))
                 .leftJoin(customer)
                 .on(chatRoom.customer.eq(customer.username))
-                .where(message.type.eq(MessageType.GENERAL))
+                .where(message.type.eq(MessageType.GENERAL).and(
+                        chatRoom.id.eq(chatRoomId)))
                 .groupBy(chatRoom.id, customer.name, customer.profileImage,
                         message.content, message.createdAt, message.readStatus)
                 .having(message.createdAt.eq(
@@ -152,7 +153,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryQueryDsl {
     }
 
     @Override
-    public ChatRoomDto findDtoByCustomer(Username customer) {
+    public ChatRoomDto findDtoByCustomer(Username customer, Long chatRoomId) {
         QChatRoom chatRoom = QChatRoom.chatRoom;
         QMessage message = QMessage.message;
         QCompany company = QCompany.company;
@@ -171,6 +172,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryQueryDsl {
                 .on(chatRoom.id.eq(message.chatRoomId))
                 .leftJoin(company)
                 .on(chatRoom.company.eq(company.username))
+                .where(chatRoom.id.eq(chatRoomId))
                 .groupBy(chatRoom.id, company.name, company.profileImage,
                         message.content, message.createdAt, message.readStatus)
                 .having(message.createdAt.eq(

--- a/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryQueryDsl.java
+++ b/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryQueryDsl.java
@@ -8,6 +8,6 @@ import org.springframework.data.domain.Pageable;
 public interface ChatRoomRepositoryQueryDsl {
     Page<ChatRoomDto> findAllDtoByCompany(Username company, Pageable pageable);
     Page<ChatRoomDto> findAllDtoByCustomer(Username company, Pageable pageable);
-    ChatRoomDto findDtoByCompany(Username company);
-    ChatRoomDto findDtoByCustomer(Username company);
+    ChatRoomDto findDtoByCompany(Username company, Long chatRoomId);
+    ChatRoomDto findDtoByCustomer(Username company, Long chatRoomId);
 }


### PR DESCRIPTION
- 문제: findDtoByCompany 메서드를 사용하여 특정 채팅방  정보를 하나 불러와야하는데 username으로만 채팅방을 찾기때문에 username에 해당하는 채팅방이 모두 불러와져 오류발생
- 해결: chatRoomId를 이용하여 특정 채팅방 정보만 가져오도록 함