### PR TITLE
실시간 읽음처리를 위하여 웹소켓세션 접속여부를 파악하도록 변경

### DIFF
--- a/src/main/java/com/junhyeong/chatchat/applications/message/SendMessageService.java
+++ b/src/main/java/com/junhyeong/chatchat/applications/message/SendMessageService.java
@@ -11,9 +11,12 @@ import com.junhyeong.chatchat.models.message.Sender;
 import com.junhyeong.chatchat.repositories.company.CompanyRepository;
 import com.junhyeong.chatchat.repositories.customer.CustomerRepository;
 import com.junhyeong.chatchat.repositories.message.MessageRepository;
+import com.junhyeong.chatchat.repositories.session.SessionRepository;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
 
 @Service
 public class SendMessageService {
@@ -21,15 +24,18 @@ public class SendMessageService {
     private final CustomerRepository customerRepository;
     private final CompanyRepository companyRepository;
     private final MessageRepository messageRepository;
+    private final SessionRepository sessionRepository;
 
     public SendMessageService(SimpMessagingTemplate messagingTemplate,
                               CustomerRepository customerRepository,
                               CompanyRepository companyRepository,
-                              MessageRepository messageRepository) {
+                              MessageRepository messageRepository,
+                              SessionRepository sessionRepository) {
         this.messagingTemplate = messagingTemplate;
         this.customerRepository = customerRepository;
         this.companyRepository = companyRepository;
         this.messageRepository = messageRepository;
+        this.sessionRepository = sessionRepository;
     }
 
     @Transactional
@@ -51,6 +57,21 @@ public class SendMessageService {
                 "/sub/chatrooms/" + saved.chatRoomId(),
                 saved.toDto()
         );
+
+        markConnectedUsersMessagesAsRead(username, message);
+    }
+
+    private void markConnectedUsersMessagesAsRead(Username username, Message message) {
+        Set<String> sessionIds = sessionRepository.getSessionIdByChatRoomId(message.chatRoomId());
+
+        for (String sessionId : sessionIds) {
+            Username connectedUsername = sessionRepository.getUsernameBySessionId(sessionId);
+
+            if (!username.equals(connectedUsername)) {
+                message.read();
+                break;
+            }
+        }
     }
 
     private Username getUsername(MessageRequest messageRequest, Long senderId) {

--- a/src/main/java/com/junhyeong/chatchat/config/WebSocketConfig.java
+++ b/src/main/java/com/junhyeong/chatchat/config/WebSocketConfig.java
@@ -1,5 +1,10 @@
 package com.junhyeong.chatchat.config;
 
+import com.junhyeong.chatchat.interceptors.ChatWebSocketHandler;
+import com.junhyeong.chatchat.interceptors.CustomHandshakeInterceptor;
+import com.junhyeong.chatchat.repositories.session.SessionRepository;
+import com.junhyeong.chatchat.utils.JwtUtil;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -9,6 +14,12 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final SessionRepository sessionRepository;
+
+    public WebSocketConfig(SessionRepository sessionRepository) {
+        this.sessionRepository = sessionRepository;
+    }
+
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/messages")
@@ -21,5 +32,15 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/sub");
         registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Bean
+    public ChatWebSocketHandler chatWebSocketHandler() {
+        return new ChatWebSocketHandler(sessionRepository);
+    }
+
+    @Bean
+    public CustomHandshakeInterceptor customHandshakeInterceptor(JwtUtil jwtUtil) {
+        return new CustomHandshakeInterceptor(jwtUtil);
     }
 }

--- a/src/main/java/com/junhyeong/chatchat/interceptors/ChatWebSocketHandler.java
+++ b/src/main/java/com/junhyeong/chatchat/interceptors/ChatWebSocketHandler.java
@@ -1,0 +1,31 @@
+package com.junhyeong.chatchat.interceptors;
+
+import com.junhyeong.chatchat.models.commom.Username;
+import com.junhyeong.chatchat.repositories.session.SessionRepository;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+public class ChatWebSocketHandler extends TextWebSocketHandler {
+    private SessionRepository sessionRepository;
+
+    public ChatWebSocketHandler(SessionRepository sessionRepository) {
+        this.sessionRepository = sessionRepository;
+    }
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        Long chatRoomId = (Long) session.getAttributes().get("chatRoomId");
+
+        Username username = (Username) session.getAttributes().get("username");
+
+        sessionRepository.addSession(chatRoomId, session.getId() , username);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        Long chatRoomId = (Long) session.getAttributes().get("chatRoomId");
+
+        sessionRepository.removeSession(chatRoomId, session.getId());
+    }
+}

--- a/src/main/java/com/junhyeong/chatchat/interceptors/CustomHandshakeInterceptor.java
+++ b/src/main/java/com/junhyeong/chatchat/interceptors/CustomHandshakeInterceptor.java
@@ -1,0 +1,54 @@
+package com.junhyeong.chatchat.interceptors;
+
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.junhyeong.chatchat.exceptions.AuthenticationError;
+import com.junhyeong.chatchat.models.commom.Username;
+import com.junhyeong.chatchat.utils.JwtUtil;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+public class CustomHandshakeInterceptor implements HandshakeInterceptor {
+    private JwtUtil jwtUtil;
+
+    public CustomHandshakeInterceptor(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        String authorization = request.getHeaders().getFirst("Authorization");
+
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            return true;
+        }
+
+        String accessToken = authorization.substring("Bearer ".length());
+
+        try {
+            Username username = jwtUtil.decode(accessToken);
+
+            attributes.put("username", username);
+
+            String requestUri = request.getURI().toString();
+
+            Long chatRoomId = Long.valueOf(requestUri.split("chatrooms/")[1]);
+
+            attributes.put("chatRoomId", chatRoomId);
+
+            return true;
+        } catch (JWTDecodeException exception) {
+            throw new AuthenticationError();
+        }
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+
+    }
+}

--- a/src/main/java/com/junhyeong/chatchat/repositories/session/SessionRepository.java
+++ b/src/main/java/com/junhyeong/chatchat/repositories/session/SessionRepository.java
@@ -1,0 +1,40 @@
+package com.junhyeong.chatchat.repositories.session;
+
+import com.junhyeong.chatchat.models.commom.Username;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Repository
+public class SessionRepository {
+    private final Map<Long, Set<String>> chatRoomSessions = new HashMap<>();
+    private final Map<String, Username> connectedUsers = new HashMap<>();
+
+    public void addSession(Long chatRoomId, String sessionId, Username username) {
+        chatRoomSessions.computeIfAbsent(chatRoomId, key -> new HashSet<>()).add(sessionId);
+
+        connectedUsers.put(sessionId, username);
+    }
+
+    public void removeSession(Long chatRoomId, String sessionId) {
+        chatRoomSessions.getOrDefault(chatRoomId, Collections.emptySet()).remove(sessionId);
+
+        connectedUsers.remove(sessionId);
+    }
+
+    public boolean isSessionConnected(Long chatRoomId, String sessionId) {
+        return chatRoomSessions.getOrDefault(chatRoomId, Collections.emptySet()).contains(sessionId);
+    }
+
+    public Set<String> getSessionIdByChatRoomId(Long chatRoomId) {
+        return chatRoomSessions.get(chatRoomId);
+    }
+
+    public Username getUsernameBySessionId(String sessionId) {
+        return connectedUsers.get(sessionId);
+    }
+}

--- a/src/test/java/com/junhyeong/chatchat/applications/message/SendMessageServiceTest.java
+++ b/src/test/java/com/junhyeong/chatchat/applications/message/SendMessageServiceTest.java
@@ -9,6 +9,7 @@ import com.junhyeong.chatchat.models.message.Message;
 import com.junhyeong.chatchat.repositories.company.CompanyRepository;
 import com.junhyeong.chatchat.repositories.customer.CustomerRepository;
 import com.junhyeong.chatchat.repositories.message.MessageRepository;
+import com.junhyeong.chatchat.repositories.session.SessionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -34,19 +35,21 @@ class SendMessageServiceTest {
     private CompanyRepository companyRepository;
     private MessageRepository messageRepository;
     private SendMessageService sendMessageService;
+    private SessionRepository sessionRepository;
 
     @BeforeEach
     void setUp() {
         customerRepository = mock(CustomerRepository.class);
         companyRepository = mock(CompanyRepository.class);
         messageRepository = mock(MessageRepository.class);
+        sessionRepository = mock(SessionRepository.class);
 
         sendMessageService = new SendMessageService(
                 messagingTemplate,
                 customerRepository,
                 companyRepository,
-                messageRepository
-        );
+                messageRepository,
+                sessionRepository);
     }
 
     @Test


### PR DESCRIPTION
- HandshakeInterceptor에서 beforeHandshake 통해 웹소켓 연결시 토큰과 연결주소를 받아오도록 함
- TextWebSocketHandler를 통해 웹소켓 연결시 세션정보를 저장하고, 종료시 삭제하도록 함
- 메시지를 전송할 때,  메시지를 받는 상대가 해당 채팅방에 접속해 있다면 읽음처리하는 코드 추가