### PR TITLE
탈퇴한 계정 처리 및 표시 변경

### DIFF
--- a/src/main/java/com/junhyeong/chatchat/applications/chatRoom/GetCustomerChatRoomsService.java
+++ b/src/main/java/com/junhyeong/chatchat/applications/chatRoom/GetCustomerChatRoomsService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class GetCustomerChatRoomsService {
+public class  GetCustomerChatRoomsService {
     private final CustomerRepository customerRepository;
     private final ChatRoomRepository chatRoomRepository;
 
@@ -33,6 +33,7 @@ public class GetCustomerChatRoomsService {
 
         Page<ChatRoomDto> chatRooms = chatRoomRepository.findAllDtoByCustomer(username, pageable);
 
+        //탈퇴 처리
         return chatRooms;
     }
 }

--- a/src/main/java/com/junhyeong/chatchat/applications/company/GetCompanyService.java
+++ b/src/main/java/com/junhyeong/chatchat/applications/company/GetCompanyService.java
@@ -1,5 +1,6 @@
 package com.junhyeong.chatchat.applications.company;
 
+import com.junhyeong.chatchat.exceptions.CompanyDeleted;
 import com.junhyeong.chatchat.exceptions.CompanyNotFound;
 import com.junhyeong.chatchat.models.commom.Username;
 import com.junhyeong.chatchat.models.company.Company;
@@ -15,10 +16,14 @@ public class GetCompanyService {
         this.companyRepository = companyRepository;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Company find(Username username) {
         Company company = companyRepository.findByUsername(username)
                 .orElseThrow(CompanyNotFound::new);
+
+        if (company.isDeleted()) {
+            throw new CompanyDeleted();
+        }
 
         return company;
     }

--- a/src/main/java/com/junhyeong/chatchat/applications/customer/GetCustomerService.java
+++ b/src/main/java/com/junhyeong/chatchat/applications/customer/GetCustomerService.java
@@ -1,5 +1,6 @@
 package com.junhyeong.chatchat.applications.customer;
 
+import com.junhyeong.chatchat.exceptions.CustomerDeleted;
 import com.junhyeong.chatchat.exceptions.CustomerNotFound;
 import com.junhyeong.chatchat.models.commom.Username;
 import com.junhyeong.chatchat.models.customer.Customer;
@@ -15,10 +16,14 @@ public class GetCustomerService {
         this.customerRepository = customerRepository;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Customer find(Username username) {
         Customer customer = customerRepository.findByUsername(username)
                 .orElseThrow(CustomerNotFound::new);
+
+        if (customer.isDeleted()) {
+            throw new CustomerDeleted();
+        }
 
         return customer;
     }

--- a/src/main/java/com/junhyeong/chatchat/applications/message/SendMessageService.java
+++ b/src/main/java/com/junhyeong/chatchat/applications/message/SendMessageService.java
@@ -1,13 +1,17 @@
 package com.junhyeong.chatchat.applications.message;
 
 import com.junhyeong.chatchat.dtos.MessageRequest;
+import com.junhyeong.chatchat.exceptions.ChatRoomNotFound;
 import com.junhyeong.chatchat.exceptions.CompanyNotFound;
 import com.junhyeong.chatchat.exceptions.CustomerNotFound;
+import com.junhyeong.chatchat.exceptions.ReceiverDeleted;
 import com.junhyeong.chatchat.exceptions.UnknownRole;
+import com.junhyeong.chatchat.models.chatRoom.ChatRoom;
 import com.junhyeong.chatchat.models.commom.Username;
 import com.junhyeong.chatchat.models.message.Message;
 import com.junhyeong.chatchat.models.message.MessageType;
 import com.junhyeong.chatchat.models.message.Sender;
+import com.junhyeong.chatchat.repositories.chatRoom.ChatRoomRepository;
 import com.junhyeong.chatchat.repositories.company.CompanyRepository;
 import com.junhyeong.chatchat.repositories.customer.CustomerRepository;
 import com.junhyeong.chatchat.repositories.message.MessageRepository;
@@ -25,27 +29,37 @@ public class SendMessageService {
     private final CompanyRepository companyRepository;
     private final MessageRepository messageRepository;
     private final SessionRepository sessionRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     public SendMessageService(SimpMessagingTemplate messagingTemplate,
                               CustomerRepository customerRepository,
                               CompanyRepository companyRepository,
                               MessageRepository messageRepository,
-                              SessionRepository sessionRepository) {
+                              SessionRepository sessionRepository,
+                              ChatRoomRepository chatRoomRepository) {
         this.messagingTemplate = messagingTemplate;
         this.customerRepository = customerRepository;
         this.companyRepository = companyRepository;
         this.messageRepository = messageRepository;
         this.sessionRepository = sessionRepository;
+        this.chatRoomRepository = chatRoomRepository;
     }
 
     @Transactional
     public void sendMessage(MessageRequest messageRequest) {
+        ChatRoom chatRoom = chatRoomRepository.findById(messageRequest.getChatRoomId())
+                .orElseThrow(ChatRoomNotFound::new);
+
+        if (isReceiverDeleted(chatRoom, messageRequest.getRole())) {
+            throw new ReceiverDeleted();
+        }
+
         Long senderId = messageRequest.getSenderId();
 
         Username username = getUsername(messageRequest, senderId);
 
         Message message = new Message(
-                messageRequest.getChatRoomId(),
+                chatRoom.id(),
                 new Sender(senderId, username),
                 messageRequest.getContent(),
                 MessageType.GENERAL
@@ -59,6 +73,18 @@ public class SendMessageService {
         );
 
         markConnectedUsersMessagesAsRead(username, message);
+    }
+
+    private boolean isReceiverDeleted(ChatRoom chatRoom, String senderRole) {
+        String receiverRole = senderRole.equals("company") ? "customer" : "company";
+
+        return switch (receiverRole) {
+            case "company" -> companyRepository.findByUsername(chatRoom.company())
+                    .orElseThrow(CompanyNotFound::new).isDeleted();
+            case "customer" -> customerRepository.findByUsername(chatRoom.customer())
+                    .orElseThrow(CustomerNotFound::new).isDeleted();
+            default -> throw new UnknownRole();
+        };
     }
 
     private void markConnectedUsersMessagesAsRead(Username username, Message message) {

--- a/src/main/java/com/junhyeong/chatchat/controllers/common/MessageController.java
+++ b/src/main/java/com/junhyeong/chatchat/controllers/common/MessageController.java
@@ -4,6 +4,7 @@ import com.junhyeong.chatchat.applications.message.SendMessageService;
 import com.junhyeong.chatchat.applications.notification.MessageNotificationService;
 import com.junhyeong.chatchat.dtos.MessageRequest;
 import com.junhyeong.chatchat.dtos.MessageRequestDto;
+import com.junhyeong.chatchat.exceptions.ReceiverDeleted;
 import com.junhyeong.chatchat.exceptions.UnknownRole;
 import org.springframework.http.HttpStatus;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -36,6 +37,12 @@ public class MessageController {
     @ExceptionHandler(UnknownRole.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String unknownRole(Exception e) {
+        return e.getMessage();
+    }
+
+    @ExceptionHandler(ReceiverDeleted.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String receiverDeleted(Exception e) {
         return e.getMessage();
     }
 }

--- a/src/main/java/com/junhyeong/chatchat/dtos/ChatRoomDetailDto.java
+++ b/src/main/java/com/junhyeong/chatchat/dtos/ChatRoomDetailDto.java
@@ -6,17 +6,19 @@ public class ChatRoomDetailDto {
     private Long id;
     private Long receiverId;
     private String receiverName;
+    private boolean isReceiverDeleted;
     private String receiverImageUrl;
     private List<MessageDto> messages;
     private PageDto page;
 
-    public ChatRoomDetailDto(Long id, Long receiverId,
-                             String receiverName, String receiverImageUrl,
+    public ChatRoomDetailDto(Long id, Long receiverId, String receiverName,
+                             String receiverImageUrl, boolean isReceiverDeleted,
                              List<MessageDto> messages, PageDto page) {
         this.id = id;
         this.receiverId = receiverId;
         this.receiverName = receiverName;
         this.receiverImageUrl = receiverImageUrl;
+        this.isReceiverDeleted = isReceiverDeleted;
         this.messages = messages;
         this.page = page;
     }
@@ -35,6 +37,10 @@ public class ChatRoomDetailDto {
 
     public String getReceiverImageUrl() {
         return receiverImageUrl;
+    }
+
+    public boolean isReceiverDeleted() {
+        return isReceiverDeleted;
     }
 
     public List<MessageDto> getMessages() {

--- a/src/main/java/com/junhyeong/chatchat/dtos/ChatRoomDto.java
+++ b/src/main/java/com/junhyeong/chatchat/dtos/ChatRoomDto.java
@@ -2,6 +2,7 @@ package com.junhyeong.chatchat.dtos;
 
 import com.junhyeong.chatchat.models.commom.Image;
 import com.junhyeong.chatchat.models.commom.Name;
+import com.junhyeong.chatchat.models.commom.Status;
 import com.junhyeong.chatchat.models.message.Content;
 
 import java.time.LocalDateTime;
@@ -15,8 +16,8 @@ public class ChatRoomDto {
     private String lastMessageDate;
     private Long unreadMessageCount;
 
-    public ChatRoomDto(Long id, Name receiverName, Image receiverImageUrl, Content lastMessage,
-                       LocalDateTime lastMessageDate, Long unreadMessageCount
+    public ChatRoomDto(Long id, Name receiverName, Image receiverImageUrl, Status receiverStatus,
+                       Content lastMessage, LocalDateTime lastMessageDate, Long unreadMessageCount
     ) {
         this.id = id;
         this.receiverName = receiverName.value();
@@ -24,10 +25,15 @@ public class ChatRoomDto {
         this.lastMessage = lastMessage.value();
         this.lastMessageDate = lastMessageDate.format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss"));
         this.unreadMessageCount = unreadMessageCount;
+
+        if (receiverStatus.equals(Status.DELETED)) {
+            this.receiverName = Name.UNKNOWN_NAME;
+            this.receiverImageUrl = Image.DEFAULT_PROFILE_IMAGE;
+        }
     }
 
     public static ChatRoomDto fake() {
-        return new ChatRoomDto(1L, new Name("고객"), new Image("이미지"),
+        return new ChatRoomDto(1L, new Name("고객"), new Image("이미지"), Status.ACTIVE,
                 new Content("내용"), LocalDateTime.of(2023, 1, 1, 1, 1), 3L);
     }
 

--- a/src/main/java/com/junhyeong/chatchat/exceptions/CompanyDeleted.java
+++ b/src/main/java/com/junhyeong/chatchat/exceptions/CompanyDeleted.java
@@ -1,0 +1,7 @@
+package com.junhyeong.chatchat.exceptions;
+
+public class CompanyDeleted extends RuntimeException {
+    public CompanyDeleted() {
+        super("탈퇴된 계정입니다.");
+    }
+}

--- a/src/main/java/com/junhyeong/chatchat/exceptions/CustomerDeleted.java
+++ b/src/main/java/com/junhyeong/chatchat/exceptions/CustomerDeleted.java
@@ -1,0 +1,7 @@
+package com.junhyeong.chatchat.exceptions;
+
+public class CustomerDeleted extends RuntimeException {
+    public CustomerDeleted() {
+        super("탈퇴된 계정입니다.");
+    }
+}

--- a/src/main/java/com/junhyeong/chatchat/exceptions/ReceiverDeleted.java
+++ b/src/main/java/com/junhyeong/chatchat/exceptions/ReceiverDeleted.java
@@ -1,0 +1,7 @@
+package com.junhyeong.chatchat.exceptions;
+
+public class ReceiverDeleted extends RuntimeException {
+    public ReceiverDeleted() {
+        super("대화가 불가능한 사용자입니다.");
+    }
+}

--- a/src/main/java/com/junhyeong/chatchat/models/commom/Name.java
+++ b/src/main/java/com/junhyeong/chatchat/models/commom/Name.java
@@ -8,6 +8,8 @@ import java.util.Objects;
 
 @Embeddable
 public class Name {
+    public static final String UNKNOWN_NAME = "(알 수 없음)";
+
     @Column(name = "name")
     private String value;
 

--- a/src/main/java/com/junhyeong/chatchat/models/company/Company.java
+++ b/src/main/java/com/junhyeong/chatchat/models/company/Company.java
@@ -6,7 +6,6 @@ import com.junhyeong.chatchat.dtos.CompanyProfileDto;
 import com.junhyeong.chatchat.dtos.MessageDto;
 import com.junhyeong.chatchat.dtos.PageDto;
 import com.junhyeong.chatchat.exceptions.AuthenticationFailed;
-import com.junhyeong.chatchat.exceptions.LoginFailed;
 import com.junhyeong.chatchat.models.commom.Image;
 import com.junhyeong.chatchat.models.commom.Name;
 import com.junhyeong.chatchat.models.commom.Password;
@@ -176,16 +175,32 @@ public class Company {
     }
 
     public ChatRoomDetailDto toRoomDetailDto(Long chatRoomId, List<MessageDto> messages, PageDto page) {
+        if (this.isDeleted()) {
+            return new ChatRoomDetailDto(
+                    chatRoomId,
+                    this.id,
+                    Name.UNKNOWN_NAME,
+                    Image.DEFAULT_PROFILE_IMAGE,
+                    this.isDeleted(),
+                    messages,
+                    page);
+        }
+
         return new ChatRoomDetailDto(
                 chatRoomId,
                 this.id,
                 this.name.value(),
                 this.profileImage.value(),
+                this.isDeleted(),
                 messages,
                 page);
     }
 
     public void delete() {
         this.status = Status.DELETED;
+    }
+
+    public boolean isDeleted() {
+        return status.equals(Status.DELETED);
     }
 }

--- a/src/main/java/com/junhyeong/chatchat/models/customer/Customer.java
+++ b/src/main/java/com/junhyeong/chatchat/models/customer/Customer.java
@@ -113,11 +113,23 @@ public class Customer {
     }
 
     public ChatRoomDetailDto toRoomDetailDto(Long chatRoomId, List<MessageDto> messages, PageDto page) {
+        if (this.isDeleted()) {
+            return new ChatRoomDetailDto(
+                    chatRoomId,
+                    this.id,
+                    Name.UNKNOWN_NAME,
+                    Image.DEFAULT_PROFILE_IMAGE,
+                    this.isDeleted(),
+                    messages,
+                    page);
+        }
+
         return new ChatRoomDetailDto(
                 chatRoomId,
                 this.id,
                 this.name.value(),
                 this.profileImage.value(),
+                this.isDeleted(),
                 messages,
                 page);
     }
@@ -133,5 +145,9 @@ public class Customer {
 
     public void delete() {
         this.status = Status.DELETED;
+    }
+
+    public boolean isDeleted() {
+        return status.equals(Status.DELETED);
     }
 }

--- a/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryImpl.java
@@ -42,6 +42,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryQueryDsl {
                         chatRoom.id,
                         customer.name,
                         customer.profileImage,
+                        customer.status,
                         message.content,
                         message.createdAt,
                         getUnreadMessageCount(chatRoom, company)
@@ -91,6 +92,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryQueryDsl {
                         chatRoom.id,
                         company.name,
                         company.profileImage,
+                        company.status,
                         message.content,
                         message.createdAt,
                         getUnreadMessageCount(chatRoom, customer)
@@ -114,71 +116,6 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryQueryDsl {
         Long count = getPageCountByCustomer(customer, chatRoom);
 
         return new PageImpl<>(chatRooms, pageable, count);
-    }
-
-    @Override
-    public ChatRoomDto findDtoByCompany(Username company, Long chatRoomId) {
-        QChatRoom chatRoom = QChatRoom.chatRoom;
-        QMessage message = QMessage.message;
-        QCustomer customer = QCustomer.customer;
-
-        return queryFactory
-                .select(Projections.constructor(ChatRoomDto.class,
-                        chatRoom.id,
-                        customer.name,
-                        customer.profileImage,
-                        message.content,
-                        message.createdAt,
-                        getUnreadMessageCount(chatRoom, company)
-                ))
-                .from(chatRoom)
-                .innerJoin(message)
-                .on(chatRoom.id.eq(message.chatRoomId))
-                .leftJoin(customer)
-                .on(chatRoom.customer.eq(customer.username))
-                .where(message.type.eq(MessageType.GENERAL).and(
-                        chatRoom.id.eq(chatRoomId)))
-                .groupBy(chatRoom.id, customer.name, customer.profileImage,
-                        message.content, message.createdAt, message.readStatus)
-                .having(message.createdAt.eq(
-                        getLastCreatedAt(chatRoom)).and(
-                        chatRoom.id.in(
-                                JPAExpressions
-                                        .selectDistinct(message.chatRoomId)
-                                        .from(message)
-                                        .where(message.type.eq(MessageType.GENERAL))
-                        )
-                ))
-                .fetchOne();
-    }
-
-    @Override
-    public ChatRoomDto findDtoByCustomer(Username customer, Long chatRoomId) {
-        QChatRoom chatRoom = QChatRoom.chatRoom;
-        QMessage message = QMessage.message;
-        QCompany company = QCompany.company;
-
-        return queryFactory
-                .select(Projections.constructor(ChatRoomDto.class,
-                        chatRoom.id,
-                        company.name,
-                        company.profileImage,
-                        message.content,
-                        message.createdAt,
-                        getUnreadMessageCount(chatRoom, customer)
-                ))
-                .from(chatRoom)
-                .leftJoin(message)
-                .on(chatRoom.id.eq(message.chatRoomId))
-                .leftJoin(company)
-                .on(chatRoom.company.eq(company.username))
-                .where(chatRoom.id.eq(chatRoomId))
-                .groupBy(chatRoom.id, company.name, company.profileImage,
-                        message.content, message.createdAt, message.readStatus)
-                .having(message.createdAt.eq(
-                        getLastCreatedAt(chatRoom)
-                ))
-                .fetchOne();
     }
 
     private Expression<Long> getUnreadMessageCount(QChatRoom chatRoom, Username username) {

--- a/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryQueryDsl.java
+++ b/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryQueryDsl.java
@@ -7,7 +7,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface ChatRoomRepositoryQueryDsl {
     Page<ChatRoomDto> findAllDtoByCompany(Username company, Pageable pageable);
-    Page<ChatRoomDto> findAllDtoByCustomer(Username company, Pageable pageable);
-    ChatRoomDto findDtoByCompany(Username company, Long chatRoomId);
-    ChatRoomDto findDtoByCustomer(Username company, Long chatRoomId);
+    Page<ChatRoomDto> findAllDtoByCustomer(Username customer, Pageable pageable);
 }

--- a/src/test/java/com/junhyeong/chatchat/applications/message/SendMessageServiceTest.java
+++ b/src/test/java/com/junhyeong/chatchat/applications/message/SendMessageServiceTest.java
@@ -2,10 +2,13 @@ package com.junhyeong.chatchat.applications.message;
 
 import com.junhyeong.chatchat.dtos.MessageDto;
 import com.junhyeong.chatchat.dtos.MessageRequest;
+import com.junhyeong.chatchat.models.chatRoom.ChatRoom;
 import com.junhyeong.chatchat.models.commom.Username;
 import com.junhyeong.chatchat.models.company.Company;
+import com.junhyeong.chatchat.models.customer.Customer;
 import com.junhyeong.chatchat.models.message.Content;
 import com.junhyeong.chatchat.models.message.Message;
+import com.junhyeong.chatchat.repositories.chatRoom.ChatRoomRepository;
 import com.junhyeong.chatchat.repositories.company.CompanyRepository;
 import com.junhyeong.chatchat.repositories.customer.CustomerRepository;
 import com.junhyeong.chatchat.repositories.message.MessageRepository;
@@ -36,6 +39,7 @@ class SendMessageServiceTest {
     private MessageRepository messageRepository;
     private SendMessageService sendMessageService;
     private SessionRepository sessionRepository;
+    private ChatRoomRepository chatRoomRepository;
 
     @BeforeEach
     void setUp() {
@@ -43,13 +47,15 @@ class SendMessageServiceTest {
         companyRepository = mock(CompanyRepository.class);
         messageRepository = mock(MessageRepository.class);
         sessionRepository = mock(SessionRepository.class);
+        chatRoomRepository = mock(ChatRoomRepository.class);
 
         sendMessageService = new SendMessageService(
                 messagingTemplate,
                 customerRepository,
                 companyRepository,
                 messageRepository,
-                sessionRepository);
+                sessionRepository,
+                chatRoomRepository);
     }
 
     @Test
@@ -71,6 +77,14 @@ class SendMessageServiceTest {
         String role = "company";
 
         MessageRequest messageRequest = MessageRequest.fake(content, role);
+
+        ChatRoom chatRoom = ChatRoom.fake(messageRequest.getChatRoomId());
+
+        given(chatRoomRepository.findById(messageRequest.getChatRoomId()))
+                .willReturn(Optional.of(chatRoom));
+
+        given(customerRepository.findByUsername(chatRoom.customer()))
+                .willReturn(Optional.of(Customer.fake(chatRoom.customer())));
 
         sendMessageService.sendMessage(messageRequest);
 


### PR DESCRIPTION
- 탈퇴한 계정은 로그인이 안되도록 변경
- 상대가 탈퇴한 계정의 프로필과 채팅을 볼때 이미지는 기본이미지, 이름은 (알 수 없음)으로 보이도록 변경
- 탈퇴한 계정에게 채팅 못보내도록 변경
- 채팅방 상세 정보 확인 시, 상대의 탈퇴여부를 확인할 수 있는 데이터를 포함하도록 변경