### PR TITLE
자동응답 질문을 기업이 아닌 고객이 보내는 걸로 수정

### DIFF
--- a/src/main/java/com/junhyeong/chatchat/applications/autoReply/SendAutoReplyService.java
+++ b/src/main/java/com/junhyeong/chatchat/applications/autoReply/SendAutoReplyService.java
@@ -8,6 +8,7 @@ import com.junhyeong.chatchat.models.autoReply.AutoReply;
 import com.junhyeong.chatchat.models.chatRoom.ChatRoom;
 import com.junhyeong.chatchat.models.commom.Username;
 import com.junhyeong.chatchat.models.company.Company;
+import com.junhyeong.chatchat.models.customer.Customer;
 import com.junhyeong.chatchat.models.message.Content;
 import com.junhyeong.chatchat.models.message.Message;
 import com.junhyeong.chatchat.models.message.MessageType;
@@ -42,9 +43,8 @@ public class SendAutoReplyService {
 
     @Transactional
     public void send(Username username, Long autoReplyId, Long chatRoomId) {
-        if (!customerRepository.existsByUsername(username)) {
-            throw new Unauthorized();
-        }
+        Customer customer = customerRepository.findByUsername(username)
+                .orElseThrow(Unauthorized::new);
 
         AutoReply autoReply = autoReplyRepository.findById(autoReplyId)
                 .orElseThrow(AutoReplyNotFound::new);
@@ -57,10 +57,11 @@ public class SendAutoReplyService {
 
         Message question = new Message(
                 chatRoom.id(),
-                new Sender(company.id(), company.username()),
+                new Sender(customer.id(), customer.username()),
                 new Content(autoReply.question().value()),
                 MessageType.AUTO
         );
+        question.read();
 
         Message answer = new Message(
                 chatRoom.id(),
@@ -68,6 +69,7 @@ public class SendAutoReplyService {
                 new Content(autoReply.answer().value()),
                 MessageType.AUTO
         );
+        answer.read();
 
         messageRepository.save(question);
         messageRepository.save(answer);

--- a/src/main/java/com/junhyeong/chatchat/controllers/common/MessageController.java
+++ b/src/main/java/com/junhyeong/chatchat/controllers/common/MessageController.java
@@ -25,7 +25,7 @@ public class MessageController {
     }
 
     @MessageMapping("/messages")
-    public void sendMessage(SimpMessageHeaderAccessor headerAccessor, MessageRequestDto messageRequestDto) {
+    public void sendMessage(MessageRequestDto messageRequestDto) {
         MessageRequest messageRequest = MessageRequest.of(messageRequestDto);
 
         sendMessageService.sendMessage(messageRequest);

--- a/src/test/java/com/junhyeong/chatchat/applications/autoReply/SendAutoReplyServiceTest.java
+++ b/src/test/java/com/junhyeong/chatchat/applications/autoReply/SendAutoReplyServiceTest.java
@@ -8,6 +8,7 @@ import com.junhyeong.chatchat.models.autoReply.AutoReply;
 import com.junhyeong.chatchat.models.chatRoom.ChatRoom;
 import com.junhyeong.chatchat.models.commom.Username;
 import com.junhyeong.chatchat.models.company.Company;
+import com.junhyeong.chatchat.models.customer.Customer;
 import com.junhyeong.chatchat.models.message.Content;
 import com.junhyeong.chatchat.models.message.Message;
 import com.junhyeong.chatchat.repositories.autoReply.AutoReplyRepository;
@@ -53,8 +54,8 @@ class SendAutoReplyServiceTest {
         Long autoReplyId = 1L;
         Long chatRoomId = 1L;
 
-        given(customerRepository.existsByUsername(username))
-                .willReturn(true);
+        given(customerRepository.findByUsername(username))
+                .willReturn(Optional.of(Customer.fake(username)));
 
         given(companyRepository.findByUsername(company))
                 .willReturn(Optional.of(Company.fake(company)));
@@ -77,8 +78,8 @@ class SendAutoReplyServiceTest {
         Long autoReplyId = 1L;
         Long chatRoomId = 1L;
 
-        given(customerRepository.existsByUsername(invalidUsername))
-                .willReturn(false);
+        given(customerRepository.findByUsername(invalidUsername))
+                .willThrow(Unauthorized.class);
 
         assertThrows(Unauthorized.class,
                 () -> sendAutoReplyService.send(invalidUsername, autoReplyId, chatRoomId));
@@ -91,8 +92,8 @@ class SendAutoReplyServiceTest {
         Long autoReplyId = 1L;
         Long chatRoomId = 1L;
 
-        given(customerRepository.existsByUsername(username))
-                .willReturn(true);
+        given(customerRepository.findByUsername(username))
+                .willReturn(Optional.of(Customer.fake(username)));
 
         given(autoReplyRepository.findById(autoReplyId))
                 .willReturn(Optional.of(AutoReply.fake(company)));
@@ -114,8 +115,8 @@ class SendAutoReplyServiceTest {
         Long autoReplyId = 999L;
         Long chatRoomId = 1L;
 
-        given(customerRepository.existsByUsername(username))
-                .willReturn(true);
+        given(customerRepository.findByUsername(username))
+                .willReturn(Optional.of(Customer.fake(username)));
 
         given(autoReplyRepository.findById(autoReplyId))
                 .willThrow(AutoReplyNotFound.class);
@@ -134,8 +135,8 @@ class SendAutoReplyServiceTest {
         Long autoReplyId = 1L;
         Long chatRoomId = 999L;
 
-        given(customerRepository.existsByUsername(username))
-                .willReturn(true);
+        given(customerRepository.findByUsername(username))
+                .willReturn(Optional.of(Customer.fake(username)));
 
         given(autoReplyRepository.findById(autoReplyId))
                 .willReturn(Optional.of(AutoReply.fake(company)));


### PR DESCRIPTION
자동응답 질문 클릭 시, 고객이 메세지로 질문을 전송한것처럼 채팅내역에 보여져야 하는데 기업이 질문, 답변 둘 다 보내게 되어있음 → 질문은 고객이 보낸걸로 수정