### PR TITLE
자동응답 기능 사용 시 채팅방이 표시되지 않는 문제 해결을 위한 having 절 수정

### DIFF
--- a/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/junhyeong/chatchat/repositories/chatRoom/ChatRoomRepositoryImpl.java
@@ -57,7 +57,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryQueryDsl {
                 .groupBy(chatRoom.id, customer.name, customer.profileImage, customer.status,
                          message.content, message.createdAt, message.readStatus)
                 .having(message.createdAt.eq(
-                        getLastCreatedAt(chatRoom)).and(
+                        getLastGeneralMessageCreatedAt(chatRoom)).and(
                         chatRoom.id.in(
                                 JPAExpressions
                                         .selectDistinct(message.chatRoomId)
@@ -106,7 +106,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryQueryDsl {
                 .groupBy(chatRoom.id, company.name, company.profileImage, company.status,
                         message.content, message.createdAt, message.readStatus)
                 .having(message.createdAt.eq(
-                        getLastCreatedAt(chatRoom)
+                        getLastMessageCreatedAt(chatRoom)
                 ))
                 .orderBy(message.createdAt.max().desc())
                 .offset(pageable.getOffset())
@@ -132,12 +132,22 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryQueryDsl {
         );
     }
 
-    private JPQLQuery<LocalDateTime> getLastCreatedAt(QChatRoom chatRoom) {
+    private JPQLQuery<LocalDateTime> getLastMessageCreatedAt(QChatRoom chatRoom) {
         QMessage message = QMessage.message;
 
         return JPAExpressions.select(message.createdAt.max())
                 .from(message)
                 .where(message.chatRoomId.eq(chatRoom.id));
+    }
+
+    private JPQLQuery<LocalDateTime> getLastGeneralMessageCreatedAt(QChatRoom chatRoom) {
+        QMessage message = QMessage.message;
+
+        return JPAExpressions.select(message.createdAt.max())
+                .from(message)
+                .where(message.chatRoomId.eq(chatRoom.id).and(
+                        message.type.eq(MessageType.GENERAL)
+                ));
     }
 
     private Long getPageCountByCompany(Username company, QChatRoom chatRoom) {


### PR DESCRIPTION
- 이슈: 자동응답 기능을 사용할 때 채팅방이 표시되지 않는 문제가 발생
- 원인: 채팅방 요약 메시지를 표시하기 위해 having 절을 사용하여 마지막 일반 메시지만 표시하도록 설정 함. 하지만 마지막 메시지를 선택할 때 자동메시지까지 고려하여 선택하게 되어, 마지막 메시지가 자동메시지인 경우에는 채팅방이 표시되지 않는 문제가 발생
- 해결: having절의 마지막 메시지의 시간을 일반메시지를 기준으로 변경